### PR TITLE
joltc-sys: native Android cross-compile + host-vs-target /EHsc fix

### DIFF
--- a/crates/joltc-sys/build.rs
+++ b/crates/joltc-sys/build.rs
@@ -28,11 +28,62 @@ fn build_joltc() {
     // features just based on opt-level.
     config.profile("Release");
 
+    // Read the actual cross-compile target rather than the build host so
+    // the rest of this fn can dispatch correctly. `cfg!(...)` would
+    // evaluate at build-script-compile time on the HOST.
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+
     // Jolt fails to compile via the cmake crate without specifying exception
     // handling behavior under MSVC. I'm not sure that this is the correct
     // exception handling mode.
-    if cfg!(windows) {
+    //
+    // The original `cfg!(windows)` is a HOST-OS check (build.rs runs on
+    // the host, so it is always true on Windows). When cross-compiling
+    // to Android from a Windows host, NDK clang receives `/EHsc` as a
+    // path argument and errors. Switch to the target check so the flag
+    // only applies to actual Windows targets.
+    if target_os == "windows" {
         config.cxxflag("/EHsc");
+    }
+
+    // Native Android cross-compile setup. Without this, building
+    // joltc-sys for Android via the standard
+    // `cargo ndk --target <android-triple> check` flow fails because
+    // (a) cmake-rs defaults to MSBuild on Windows hosts which can't
+    // target Android; (b) the NDK's `android.toolchain.cmake` requires
+    // `ANDROID_ABI` to be set as a CMake variable (env var is
+    // ignored); (c) `ANDROID_NDK_HOME` is the canonical env name set
+    // by `nttld/setup-ndk` GitHub Action + cargo-ndk's local
+    // workflow.
+    //
+    // We translate cargo's target arch to NDK's ABI string and route
+    // CMake through the NDK toolchain file. `ANDROID_PLATFORM=android-21`
+    // is the same baseline most cargo-ndk users target.
+    if target_os == "android" {
+        let android_ndk_home = env::var("ANDROID_NDK_HOME")
+            .or_else(|_| env::var("ANDROID_NDK_ROOT"))
+            .or_else(|_| env::var("ANDROID_NDK"))
+            .expect(
+                "Android cross-compile requires ANDROID_NDK_HOME (or ANDROID_NDK_ROOT / \
+                 ANDROID_NDK) to point at the NDK install. Install via \
+                 `nttld/setup-ndk@v1` in CI or the Android SDK manager locally.",
+            );
+        let toolchain_file = format!("{android_ndk_home}/build/cmake/android.toolchain.cmake");
+        config.define("CMAKE_TOOLCHAIN_FILE", &toolchain_file);
+        let android_abi = match target_arch.as_str() {
+            "aarch64" => "arm64-v8a",
+            "arm" => "armeabi-v7a",
+            "x86" => "x86",
+            "x86_64" => "x86_64",
+            _ => panic!("unsupported Android target arch: {target_arch}"),
+        };
+        config.define("ANDROID_ABI", android_abi);
+        config.define("ANDROID_PLATFORM", "android-21");
+        // cmake-rs defaults to the host-OS generator (MSBuild on Win);
+        // the NDK toolchain only supports Ninja / Makefiles. Force
+        // Ninja explicitly.
+        config.generator("Ninja");
     }
 
     // Having IPO/LTO turned on breaks lld on Windows.

--- a/crates/joltc-sys/build.rs
+++ b/crates/joltc-sys/build.rs
@@ -37,12 +37,6 @@ fn build_joltc() {
     // Jolt fails to compile via the cmake crate without specifying exception
     // handling behavior under MSVC. I'm not sure that this is the correct
     // exception handling mode.
-    //
-    // The original `cfg!(windows)` is a HOST-OS check (build.rs runs on
-    // the host, so it is always true on Windows). When cross-compiling
-    // to Android from a Windows host, NDK clang receives `/EHsc` as a
-    // path argument and errors. Switch to the target check so the flag
-    // only applies to actual Windows targets.
     if target_os == "windows" {
         config.cxxflag("/EHsc");
     }


### PR DESCRIPTION
## Summary

Two coupled bugs surfaced while cross-compiling `joltc-sys` to Android (aarch64-linux-android via NDK r26d clang from a Windows host).

### 1. `cfg!(windows)` is a HOST-OS check, not a target-OS check

`build.rs` runs on the host. When the host is Windows and the target is Android, the existing `if cfg!(windows) { config.cxxflag("/EHsc"); }` unconditionally appends the MSVC-only `/EHsc` flag. NDK clang then receives `/EHsc` as a path argument and errors with `no such file or directory: '/EHsc'`.

**Fix:** read `CARGO_CFG_TARGET_OS` and gate `/EHsc` on the actual target.

### 2. Native Android cross-compile setup is missing

Building for Android via the standard `cargo ndk --target <android-triple> check -p joltc-sys` flow currently fails because `joltc-sys` does not set:

- `CMAKE_TOOLCHAIN_FILE` (NDK's `build/cmake/android.toolchain.cmake`).
- `ANDROID_ABI` (the toolchain reads it as a CMake `-D` variable; env var is ignored).
- The CMake generator (cmake-rs defaults to MSBuild on Windows hosts; the NDK toolchain only supports Ninja / Makefiles).

**Fix:** when `target_os == "android"`, derive `ANDROID_ABI` from `CARGO_CFG_TARGET_ARCH` (`aarch64` → `arm64-v8a`, `arm` → `armeabi-v7a`, `x86` / `x86_64` 1:1), resolve the NDK from `ANDROID_NDK_HOME` / `ANDROID_NDK_ROOT` / `ANDROID_NDK`, force `Ninja`, and pin `ANDROID_PLATFORM=android-21`.

## End-user contract after this change

```sh
export ANDROID_NDK_HOME=/path/to/ndk      # or ANDROID_NDK_ROOT / ANDROID_NDK
cargo ndk --target aarch64-linux-android check -p joltc-sys
```

The standard cargo-ndk + `nttld/setup-ndk@v1` GitHub Action workflow Just Works.

## Validation

- Locally validated on Windows host → aarch64-linux-android with NDK r26d. Full `JoltPhysics + JoltC + joltc-sys + rolt` cross-compile completes in ~20s. Downstream Rust crate (Titan engine's `titan-jolt-3d`) builds against the cross-compiled libs.
- `armv7-linux-androideabi` is **not addressed by this PR** — it hits an unrelated `JoltC` `LAYOUT_COMPATIBLE` static_assert (`JPC_*Settings` 16-byte alignment vs `JPH::*Settings` 8-byte alignment on 32-bit ARM). That looks like a JoltC-side ABI bug for 32-bit targets; happy to track separately.
- Desktop targets (Win/Linux/macOS) are unaffected — Android branch is gated on `target_os == "android"`, and the `/EHsc` change only narrows the existing condition (Windows targets still get it).

## Test plan

- [x] `cargo check -p joltc-sys` on Windows host (default target, x86_64-pc-windows-msvc) — `/EHsc` still applied; existing behavior unchanged.
- [x] `cargo ndk --target aarch64-linux-android check -p joltc-sys` on Windows host — succeeds with only `ANDROID_NDK_HOME` set.
- [ ] `cargo ndk --target aarch64-linux-android check -p joltc-sys` on Linux + macOS hosts — reviewer to validate; should be the simpler case (no `/EHsc` hot path).
- [ ] `cargo check -p joltc-sys` on Linux/macOS — unaffected; existing CI covers.

Opened from the same Titan-engine fork that submitted SecondHalfGames/JoltC#23 (the `JPC_PhysicsSystem_SetGravity` export). Both PRs are independent — happy to address review feedback on either.