### PR TITLE
joltc-sys: add cross-platform-deterministic cargo feature

### DIFF
--- a/crates/joltc-sys/Cargo.toml
+++ b/crates/joltc-sys/Cargo.toml
@@ -20,6 +20,24 @@ double-precision = []
 # Changes ObjectLayer and related types to be u32 instead of u16.
 object-layer-u32 = []
 
+# Pins JoltPhysics' floating-point flags to the cross-platform-deterministic
+# settings JPH gates on its `CROSS_PLATFORM_DETERMINISTIC` CMake variable
+# (see JoltPhysics' `Build/CMakeLists.txt` + `Jolt/Jolt.cmake`):
+# - MSVC: `/fp:fast` (default) → `/fp:precise`
+# - Clang ≥14: `+ -ffp-contract=off` (so mul+add doesn't fold into FMA inside
+#   `JPH_PRECISE_MATH_OFF` blocks)
+# - x86: `USE_FMADD AND NOT CROSS_PLATFORM_DETERMINISTIC` flips FMADD off
+#
+# Required for cross-platform-deterministic builds (P2P-deterministic netcode,
+# rollback-replayable simulation). Without this feature, the C++ build picks
+# the platform default — most acutely problematic on Windows MSVC where
+# `/fp:fast` is the default, producing non-deterministic floating point even
+# at the same git SHA on the same machine when toolchain settings differ.
+#
+# Default-off; ~10% perf cost (FMA disabled, more conservative FP rules).
+# Mirrors the `enhanced-determinism` cargo feature shape on rapier3d.
+cross-platform-deterministic = []
+
 [dependencies]
 
 [build-dependencies]

--- a/crates/joltc-sys/build.rs
+++ b/crates/joltc-sys/build.rs
@@ -54,6 +54,17 @@ fn build_joltc() {
         config.define("USE_ASSERTS", "ON");
     }
 
+    // Pin JoltPhysics' floating-point flags to the cross-platform-
+    // deterministic settings JPH gates on the same-named CMake var
+    // (see Build/CMakeLists.txt + Jolt/Jolt.cmake). MSVC swaps
+    // /fp:fast → /fp:precise; Clang ≥14 adds -ffp-contract=off; x86
+    // disables FMADD. Required for cross-platform-deterministic
+    // builds (P2P-deterministic netcode, rollback-replayable sims).
+    // ~10% perf cost; mirrors rapier3d's `enhanced-determinism`.
+    if cfg!(feature = "cross-platform-deterministic") {
+        config.define("CROSS_PLATFORM_DETERMINISTIC", "ON");
+    }
+
     let mut dst = config.build();
 
     // Jolt and JoltC put libraries in the 'lib' subfolder. This goes against


### PR DESCRIPTION
JoltPhysics gates three FP-determinism decisions on the
`CROSS_PLATFORM_DETERMINISTIC` CMake variable
(`Build/CMakeLists.txt:185-198, 226-244` + `Jolt/Jolt.cmake:615-678`):

- MSVC: `/fp:fast` (default) → `/fp:precise`
- Clang ≥14: `+ -ffp-contract=off` (so mul+add doesn't fold into FMA inside `JPH_PRECISE_MATH_OFF` blocks)
- x86: `USE_FMADD AND NOT CROSS_PLATFORM_DETERMINISTIC` flips FMADD off

`joltc-sys`'s `build.rs` never plumbed this through, so the C++ build picked the platform default — most acutely problematic on Windows MSVC where `/fp:fast` meant the same git SHA produced non-deterministic floating-point output across machines / runs / toolchain versions. P2P-deterministic netcode and rollback-replayable simulation can't reliably build on top of `joltc-sys` without a workaround.

This PR adds a new `cross-platform-deterministic` cargo feature on `joltc-sys` (default-off; ~10% perf cost) that defines `CROSS_PLATFORM_DETERMINISTIC=ON` during the joltc CMake build. Mirrors the `enhanced-determinism` shape on `rapier3d`.

## Verification

Downstream consumer (`Solidor777/Titan`'s `tools/titan-determinism` harness) ran a 4-platform CI sweep with the feature on:
- Windows-x64 MSVC
- Linux-x64 Clang
- macOS-ARM64 Apple Clang
- Linux-ARM64 Clang

All four platforms produced bit-identical output for a fixed scene (5 dynamic bodies + halfspace ground) stepped 60 frames at fixed 1/60s timestep. Determinism contract holds.

## Default-off rationale

P2P-deterministic netcode is opt-in (most projects ship server-authoritative or single-player). The ~10% perf cost (FMA disabled, more conservative FP rules) shouldn't be paid by projects that don't need it.